### PR TITLE
Merge initial Vector<T> implementation

### DIFF
--- a/include/Vector.h
+++ b/include/Vector.h
@@ -5,8 +5,7 @@
 
 /*
 To Do:
-push_back, pop_back
-Possibly resize or reserve for memory management.
+push_back
 Can update copy operator so that if capacity_ > other.size_, ptr_ is not deleted.
 */
 
@@ -23,8 +22,11 @@ class Vector {
         const T& at(unsigned long i) const;
         void reserve(unsigned long capacity);
         void resize(unsigned long newSize);
+        void pop_back();
+        // void push_back();
 
         unsigned long size() const { return size_; };
+        unsigned long capacity() const { return capacity_; };
 
 
     private:
@@ -123,6 +125,13 @@ void Vector<T>::resize(unsigned long newSize) {
         }
     }    
     size_ = newSize;
+}
+
+template <typename T>
+void Vector<T>::pop_back() {
+    if (size_ > 0) {
+        size_ -= 1;
+    }
 }
 
 template <typename T>

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -4,7 +4,9 @@
 /*
 To Do:
 push_back, pop_back
-operator[] for element access
+operator[]
+size()
+at()
 Possibly resize or reserve for memory management.
 */
 
@@ -19,6 +21,9 @@ class Vector {
     private:
         T* ptr_ = nullptr;
         unsigned long size_;
+
+        // Helper functions
+        void copyFrom(const Vector& other);
 };
 
 template <typename T>
@@ -37,6 +42,35 @@ Vector<T>::Vector(unsigned long size, T value) : size_(size) {
 template <typename T>
 Vector<T>::~Vector() {
     delete[] ptr_;
+}
+
+template <typename T>
+Vector<T>::Vector(const Vector& other) {
+    copyFrom(other);
+}
+
+template <typename T>
+Vector<T>& Vector<T>::operator=(const Vector<T>& other) {
+    if (this == &other) {
+        return *this;
+    }
+    delete[] ptr_;
+    copyFrom(other);
+    return *this;
+}
+
+template <typename T>
+void Vector<T>::copyFrom(const Vector<T>& other) {
+    size_ = other.size_;
+    if (size_ > 0) {
+        ptr_ = new T[size_];
+        for (unsigned long i = 0; i < size_; ++i) {
+            ptr_[i] = other.ptr_[i];
+        }
+    }
+    else {
+        ptr_ = nullptr;
+    }
 }
 
 #endif

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -1,0 +1,19 @@
+#ifndef VECTOR_H
+#define VECTOR_H
+
+template <typename T>
+class Vector {
+    public:
+        Vector(unsigned long size = 0, T value = T());
+        ~Vector();
+        Vector(const Vector& other);
+        Vector& operator=(const Vector& other);
+
+    private:
+        T* ptr_ = nullptr;
+        unsigned long size_ = 0;
+};
+
+
+
+#endif

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -7,6 +7,7 @@
 To Do:
 push_back, pop_back
 Possibly resize or reserve for memory management.
+Can update copy operator so that if capacity_ > other.size_, ptr_ is not deleted.
 */
 
 template <typename T>
@@ -21,6 +22,7 @@ class Vector {
         T& at(unsigned long i);
         const T& at(unsigned long i) const;
         void reserve(unsigned long capacity);
+        void resize(unsigned long newSize);
 
         unsigned long size() const { return size_; };
 
@@ -96,9 +98,37 @@ const T& Vector<T>::at(unsigned long i) const {
         throw std::out_of_range("Index out of range");
     }
 }
+
+template <typename T>
+void Vector<T>::reserve(unsigned long capacity) {
+    if (capacity <= size_) {
+        return;
+    }
+    T* tmpPtr = new T[capacity];
+    for (unsigned long i = 0; i < size_; ++i) {
+        tmpPtr[i] = ptr_[i];
+    }
+    delete[] ptr_;
+    ptr_ = tmpPtr;
+    capacity_ = capacity;
+
+}
+
+template <typename T>
+void Vector<T>::resize(unsigned long newSize) {
+    if (newSize > size_) {
+        reserve(newSize);
+        for (unsigned long i = size_; i < newSize; ++i) {
+            ptr_[i] = T();
+        }
+    }    
+    size_ = newSize;
+}
+
 template <typename T>
 void Vector<T>::copyFrom(const Vector<T>& other) {
     size_ = other.size_;
+    capacity_ = size_;
     if (size_ > 0) {
         ptr_ = new T[size_];
         for (unsigned long i = 0; i < size_; ++i) {

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -103,7 +103,7 @@ const T& Vector<T>::at(unsigned long i) const {
 
 template <typename T>
 void Vector<T>::reserve(unsigned long capacity) {
-    if (capacity <= size_) {
+    if (capacity <= capacity_) {
         return;
     }
     T* tmpPtr = new T[capacity];

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -23,7 +23,7 @@ class Vector {
         void reserve(unsigned long capacity);
         void resize(unsigned long newSize);
         void pop_back();
-        // void push_back();
+        void push_back(T value);
 
         unsigned long size() const { return size_; };
         unsigned long capacity() const { return capacity_; };
@@ -132,6 +132,15 @@ void Vector<T>::pop_back() {
     if (size_ > 0) {
         size_ -= 1;
     }
+}
+
+template <typename T>
+void Vector<T>::push_back(T value) {
+    if (capacity_ < 1 + size_) {
+        reserve((1 + size_) *2);
+    }
+    size_ += 1;
+    ptr_[size_ - 1] = value;
 }
 
 template <typename T>

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -17,6 +17,11 @@ class Vector {
         ~Vector();
         Vector(const Vector& other);
         Vector& operator=(const Vector& other);
+        T& operator[](unsigned long i);
+        const T& operator[](unsigned long i) const;
+
+        unsigned long size() const { return size_; };
+
 
     private:
         T* ptr_ = nullptr;
@@ -57,6 +62,16 @@ Vector<T>& Vector<T>::operator=(const Vector<T>& other) {
     delete[] ptr_;
     copyFrom(other);
     return *this;
+}
+
+template<typename T>
+T& Vector<T>::operator[](unsigned long i) {
+    return ptr_[i];
+}
+
+template<typename T>
+const T& Vector<T>::operator[](unsigned long i) const {
+    return ptr_[i];
 }
 
 template <typename T>

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -1,12 +1,11 @@
 #ifndef VECTOR_H
 #define VECTOR_H
 
+#include <stdexcept>
+
 /*
 To Do:
 push_back, pop_back
-operator[]
-size()
-at()
 Possibly resize or reserve for memory management.
 */
 
@@ -19,6 +18,9 @@ class Vector {
         Vector& operator=(const Vector& other);
         T& operator[](unsigned long i);
         const T& operator[](unsigned long i) const;
+        T& at(unsigned long i);
+        const T& at(unsigned long i) const;
+        void reserve(unsigned long capacity);
 
         unsigned long size() const { return size_; };
 
@@ -26,13 +28,14 @@ class Vector {
     private:
         T* ptr_ = nullptr;
         unsigned long size_;
+        unsigned long capacity_;
 
         // Helper functions
         void copyFrom(const Vector& other);
 };
 
 template <typename T>
-Vector<T>::Vector(unsigned long size, T value) : size_(size) {
+Vector<T>::Vector(unsigned long size, T value) : size_(size), capacity_(size) {
     if (size_ > 0) {
         ptr_ = new T[size_];
         for (unsigned long i = 0; i < size_; ++i) {
@@ -74,6 +77,25 @@ const T& Vector<T>::operator[](unsigned long i) const {
     return ptr_[i];
 }
 
+template <typename T>
+T& Vector<T>::at(unsigned long i) {
+    if (i < size_) {
+        return ptr_[i];
+    }
+    else {
+        throw std::out_of_range("Index out of range");
+    }
+}
+
+template <typename T>
+const T& Vector<T>::at(unsigned long i) const {
+    if (i < size_) {
+        return ptr_[i];
+    }
+    else {
+        throw std::out_of_range("Index out of range");
+    }
+}
 template <typename T>
 void Vector<T>::copyFrom(const Vector<T>& other) {
     size_ = other.size_;

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -27,11 +27,12 @@ class Vector {
         void shrink_to_fit();
 
         bool empty() const;
+        T* begin();
+        T* end();
         unsigned long size() const { return size_; };
         unsigned long capacity() const { return capacity_; };
         T* data() { return ptr_; }
         const T* data() const { return ptr_; }
-
 
     private:
         T* ptr_ = nullptr;
@@ -176,6 +177,16 @@ bool Vector<T>::empty() const {
         return false;
     }
     return true;
+}
+
+template <typename T>
+T* Vector<T>::begin() {
+    return ptr_;
+}
+
+template <typename T>
+T* Vector<T>::end() {
+    return (ptr_ + size_);
 }
 
 template <typename T>

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -27,6 +27,8 @@ class Vector {
 
         unsigned long size() const { return size_; };
         unsigned long capacity() const { return capacity_; };
+        T* data() { return ptr_; }
+        const T* data() const { return ptr_; }
 
 
     private:
@@ -66,8 +68,18 @@ Vector<T>& Vector<T>::operator=(const Vector<T>& other) {
     if (this == &other) {
         return *this;
     }
-    delete[] ptr_;
-    copyFrom(other);
+    if (other.size_ <= capacity_) {
+        for (unsigned long i = 0; i < other.size_; ++i) {
+            ptr_[i] = other.ptr_[i];
+        }
+        size_ = other.size_;
+    }
+    else {
+        delete[] ptr_;
+        capacity_ = 0;
+        ptr_ = nullptr;
+        copyFrom(other);
+    }
     return *this;
 }
 

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -24,7 +24,9 @@ class Vector {
         void resize(unsigned long newSize);
         void pop_back();
         void push_back(T value);
+        void shrink_to_fit();
 
+        bool empty() const;
         unsigned long size() const { return size_; };
         unsigned long capacity() const { return capacity_; };
         T* data() { return ptr_; }
@@ -153,6 +155,27 @@ void Vector<T>::push_back(T value) {
     }
     size_ += 1;
     ptr_[size_ - 1] = value;
+}
+
+template <typename T>
+void Vector<T>::shrink_to_fit() {
+    if (capacity_ > size_) {
+        T* tmpPtr = ptr_;
+        ptr_ = new T[size_];
+        for (unsigned long i = 0; i < size_; ++i) {
+            ptr_[i] = tmpPtr[i];
+        }
+        delete[] tmpPtr;
+        capacity_ = size_;
+    }
+}
+
+template <typename T>
+bool Vector<T>::empty() const {
+    if (size_ > 0) {
+        return false;
+    }
+    return true;
 }
 
 template <typename T>

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -1,6 +1,13 @@
 #ifndef VECTOR_H
 #define VECTOR_H
 
+/*
+To Do:
+push_back, pop_back
+operator[] for element access
+Possibly resize or reserve for memory management.
+*/
+
 template <typename T>
 class Vector {
     public:
@@ -11,9 +18,25 @@ class Vector {
 
     private:
         T* ptr_ = nullptr;
-        unsigned long size_ = 0;
+        unsigned long size_;
 };
 
+template <typename T>
+Vector<T>::Vector(unsigned long size, T value) : size_(size) {
+    if (size_ > 0) {
+        ptr_ = new T[size_];
+        for (unsigned long i = 0; i < size_; ++i) {
+            ptr_[i] = value;
+        }
+    }
+    else {
+        ptr_ = nullptr;
+    }
+}
 
+template <typename T>
+Vector<T>::~Vector() {
+    delete[] ptr_;
+}
 
 #endif

--- a/tests/VectorTests.cpp
+++ b/tests/VectorTests.cpp
@@ -132,3 +132,19 @@ TEST(VectorTest, EmptyWithCapacity) {
     EXPECT_EQ(v.capacity(), 10);
     EXPECT_TRUE(v.empty());
 }
+
+TEST(VectorTest, BeginData) {
+    Vector<int> v(10,0);
+    for (int i = 0; i < 10; ++i) {
+        v[i] = i;
+    }
+    EXPECT_EQ(v[0], *(v.begin()));
+}
+
+TEST(VectorTest, EndData) {
+    Vector<int> v(10,0);
+    for (int i = 0; i < 10; ++i) {
+        v[i] = i;
+    }
+    EXPECT_EQ(v[9], *(v.end()-1));
+}

--- a/tests/VectorTests.cpp
+++ b/tests/VectorTests.cpp
@@ -56,5 +56,10 @@ TEST(VectorTest, PopBack) {
     EXPECT_EQ(v.capacity(), 10);
 }
 
-// TEST(VectorTest, push_back) {
-// }
+TEST(VectorTest, PushBack) {
+    Vector<float> v(10, 0);
+    v.push_back(3.1415);
+    EXPECT_EQ(v.size(), 11);
+    EXPECT_NEAR(v[10], 3.1415, 1e-7);
+    EXPECT_EQ(v.capacity(), 22);
+}

--- a/tests/VectorTests.cpp
+++ b/tests/VectorTests.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include "Vector.h"
+
+TEST(VectorTest, DefaultConstructor) {
+    Vector<int> v;
+}
+
+TEST(VectorTest, ConstructorWithDefaultInitialization) {
+    Vector<float> v2(10);
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_EQ(v2[i], 0.0);
+    }
+}
+
+TEST(VectorTest, ConstructorWithNonZeroDefaultInitialization) {
+    Vector<double> v2(10, 3.141592653589793);
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_NEAR(v2[i], 3.141592653589793, 1e-14);
+    }
+}

--- a/tests/VectorTests.cpp
+++ b/tests/VectorTests.cpp
@@ -43,12 +43,52 @@ TEST(VectorTest, Reserve) {
     EXPECT_EQ(v.capacity(), 10);
 }
 
-TEST(VectorTest, Resize) {
+TEST(VectorTest, ResizeLarger) {
     Vector<int> v(10,0);
     v.resize(20);
     EXPECT_EQ(v.size(), 20);
 }
 
+TEST(VectorTest, ResizeSmaller) {
+    Vector<int> v(10,0);
+    v.resize(5);
+    EXPECT_EQ(v.size(), 5);
+    EXPECT_EQ(v.capacity(), 10);
+}
+TEST(VectorTest, ResizeReuseIfCapacityLargeEnough) {
+    Vector<int> v(10,0);
+    int* oldPtr = &v[0];
+    v.resize(5);
+    EXPECT_EQ(v.capacity(), 10);
+    EXPECT_EQ(&v[0], oldPtr);
+}
+
+TEST(VectorTest, ResizeInitializesOnlyNewElements) {
+    Vector<int> v(5, 1);
+    v.resize(10);
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(v[i], 1);
+    }
+    for (int i = 5; i < 10; ++i) {
+        EXPECT_EQ(v[i], 0);
+    }
+}
+
+TEST(VectorTest, AssignmentOperatorReuseIfCapacityLargeEnough) {
+    Vector<float> v(10,1.0), v2(5,3.1415);
+    float* oldPtr = &v[0];
+    v = v2;
+    EXPECT_EQ(v.capacity(), 10);
+    EXPECT_EQ(&v[0], oldPtr);
+}
+
+TEST(VectorTest, SelfAssignment) {
+    Vector<long> v(10,3);
+    v = v;
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_EQ(v[i], 3);
+    }
+}
 TEST(VectorTest, PopBack) {
     Vector<float> v(10);
     v.pop_back();
@@ -62,4 +102,9 @@ TEST(VectorTest, PushBack) {
     EXPECT_EQ(v.size(), 11);
     EXPECT_NEAR(v[10], 3.1415, 1e-7);
     EXPECT_EQ(v.capacity(), 22);
+}
+
+TEST(VectorTest, DataPointerMatchesIndexZero) {
+    Vector<int> v(10, 6);
+    EXPECT_EQ(v.data(), &v[0]);
 }

--- a/tests/VectorTests.cpp
+++ b/tests/VectorTests.cpp
@@ -108,3 +108,27 @@ TEST(VectorTest, DataPointerMatchesIndexZero) {
     Vector<int> v(10, 6);
     EXPECT_EQ(v.data(), &v[0]);
 }
+
+TEST(VectorTest, ShrinkToCapacity) {
+    Vector<int> v;
+    v.reserve(20);
+    v.resize(10);
+    EXPECT_EQ(v.size(), 10);
+    EXPECT_EQ(v.capacity(), 20);
+    int* oldPtr = v.data();
+    v.shrink_to_fit();
+    EXPECT_EQ(v.capacity(), 10);
+    EXPECT_NE(v.data(), oldPtr);
+}
+
+TEST(VectorTest, EmptyNoCapacity) {
+    Vector<int> v;
+    EXPECT_TRUE(v.empty());
+}
+
+TEST(VectorTest, EmptyWithCapacity) {
+    Vector<int> v(10,0);
+    v.resize(0);
+    EXPECT_EQ(v.capacity(), 10);
+    EXPECT_TRUE(v.empty());
+}

--- a/tests/VectorTests.cpp
+++ b/tests/VectorTests.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "Vector.h"
+#include <stdexcept>
 
 TEST(VectorTest, DefaultConstructor) {
     Vector<int> v;
@@ -17,4 +18,16 @@ TEST(VectorTest, ConstructorWithNonZeroDefaultInitialization) {
     for (int i = 0; i < 10; ++i) {
         EXPECT_NEAR(v2[i], 3.141592653589793, 1e-14);
     }
+}
+
+TEST(VectorTest, UsingAt) {
+    Vector<double> v2(10, 3.141592653589793);
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_NEAR(v2.at(i), 3.141592653589793, 1e-14);
+    }
+}
+
+TEST(VectorTest, OutOfBoundsErrorWithAt) {
+    Vector<float> v2(10, 3.141592653589793);
+    EXPECT_THROW(v2.at(11), std::out_of_range);
 }

--- a/tests/VectorTests.cpp
+++ b/tests/VectorTests.cpp
@@ -31,3 +31,30 @@ TEST(VectorTest, OutOfBoundsErrorWithAt) {
     Vector<float> v2(10, 3.141592653589793);
     EXPECT_THROW(v2.at(11), std::out_of_range);
 }
+
+TEST(VectorTest, Size) {
+    Vector<unsigned short> v(10,0);
+    EXPECT_EQ(v.size(), 10);
+}
+
+TEST(VectorTest, Reserve) {
+    Vector<char> v;
+    v.reserve(10);
+    EXPECT_EQ(v.capacity(), 10);
+}
+
+TEST(VectorTest, Resize) {
+    Vector<int> v(10,0);
+    v.resize(20);
+    EXPECT_EQ(v.size(), 20);
+}
+
+TEST(VectorTest, PopBack) {
+    Vector<float> v(10);
+    v.pop_back();
+    EXPECT_EQ(v.size(), 9);
+    EXPECT_EQ(v.capacity(), 10);
+}
+
+// TEST(VectorTest, push_back) {
+// }


### PR DESCRIPTION
This pull request merges the first version of a manually implemented Vector<T> class into main. It includes:

-     Dynamic memory management (allocation, resizing, shrink-to-fit)
-     Element access via operator[] and at()
-     Core modifiers: push_back, pop_back, reserve, resize 
-     STL-like methods: begin, end, empty, data, size, capacity 
-     Unit tests verifying correctness and memory reuse
-     Structure left open for future development (move semantics, iterators, etc.)

This represents a clean and test-covered milestone for core functionality.